### PR TITLE
Fix regex for cleaning discussion titles

### DIFF
--- a/.github/workflows/clean-discussion-titles.yml
+++ b/.github/workflows/clean-discussion-titles.yml
@@ -20,7 +20,7 @@ jobs:
             
             // Define patterns to remove (case-insensitive)
             const patterns = [
-              /^\[?FR\]?:?[^\w]\s*/i,
+              /^\[?FR[\]:\s-]{1,}\s*/i,
               /^\[?Feature\s*request\]?:?\s*/i,
               /^Feature\s*request:?\s*/i,
               /^\[?FR\s*-\s*/i,

--- a/.github/workflows/clean-discussion-titles.yml
+++ b/.github/workflows/clean-discussion-titles.yml
@@ -20,7 +20,7 @@ jobs:
             
             // Define patterns to remove (case-insensitive)
             const patterns = [
-              /^\[?FR\]?:?\s*/i,
+              /^\[?FR\]?:?[^\w]\s*/i,
               /^\[?Feature\s*request\]?:?\s*/i,
               /^Feature\s*request:?\s*/i,
               /^\[?FR\s*-\s*/i,


### PR DESCRIPTION
The current pattern matches everthing starting with `fr`, so also `Fritz...` or `French...` - see

- https://github.com/orgs/home-assistant/discussions/3892
- https://github.com/orgs/home-assistant/discussions/3735
- https://github.com/orgs/home-assistant/discussions/2313

<img width="230" height="263" alt="image" src="https://github.com/user-attachments/assets/564bea96-8dd7-4e2e-a072-c563d6cd17db" />

With the fixed pattern, only the intended variations of `[FR]:` matches:

<img width="277" height="265" alt="image" src="https://github.com/user-attachments/assets/3bb8d78b-bb9b-46cb-b2af-37c2358ea53e" />
